### PR TITLE
refactor: Move ReadWriteServiceServer implementation out of cx34.Client.

### DIFF
--- a/cmd/cx34collector/cx34collector.go
+++ b/cmd/cx34collector/cx34collector.go
@@ -114,7 +114,7 @@ func run(ctx context.Context) error {
 		}
 		s := grpc.NewServer()
 		chiltrix.RegisterHistorianServer(s, db.HistorianService())
-		chiltrix.RegisterReadWriteServiceServer(s, cxClient)
+		chiltrix.RegisterReadWriteServiceServer(s, cxClient.ReadWriteServiceServer())
 		if err := s.Serve(lis); err != nil {
 			return fmt.Errorf("failed to serve: %w", err)
 		}

--- a/cmd/cx34control/cx34control.go
+++ b/cmd/cx34control/cx34control.go
@@ -82,7 +82,7 @@ func run(ctx context.Context) error {
 			return fmt.Errorf("failed to listen: %w", err)
 		}
 		s := grpc.NewServer()
-		chiltrix.RegisterReadWriteServiceServer(s, cxClient)
+		chiltrix.RegisterReadWriteServiceServer(s, cxClient.ReadWriteServiceServer())
 		reflection.Register(s)
 		glog.Infof("cx34control server listening on :%d", *grpcPort)
 		if err := s.Serve(lis); err != nil {

--- a/cx34/BUILD.bazel
+++ b/cx34/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cx34.go",
         "cx34_diffs.go",
+        "cx34_readwriteservice.go",
         "cx34_registers.go",
     ],
     importpath = "github.com/gonzojive/heatpump/cx34",

--- a/cx34/cx34_readwriteservice.go
+++ b/cx34/cx34_readwriteservice.go
@@ -1,0 +1,36 @@
+package cx34
+
+import (
+	"context"
+
+	"github.com/gonzojive/heatpump/proto/chiltrix"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ReadWriteServiceServer is an implementation of the Chiltrix ReadWriteService
+// that uses a local cx34 client to communicate with the heat pump.
+type ReadWriteServiceServer struct {
+	chiltrix.UnimplementedReadWriteServiceServer
+	client *Client
+}
+
+var (
+	_ chiltrix.ReadWriteServiceServer = (*ReadWriteServiceServer)(nil)
+)
+
+// SetParameter implements the SetParameter method of the
+// [chiltrix.ReadWriteServiceServer] interface.
+func (s *ReadWriteServiceServer) SetParameter(ctx context.Context, req *chiltrix.SetParameterRequest) (*chiltrix.SetParameterResponse, error) {
+	return s.client.SetParameter(ctx, req)
+}
+
+// GetState implements the GetState method of the
+// [chiltrix.ReadWriteServiceServer] interface.
+func (s *ReadWriteServiceServer) GetState(ctx context.Context, _ *chiltrix.GetStateRequest) (*chiltrix.State, error) {
+	state, err := s.client.ReadState()
+	if err != nil {
+		status.Errorf(codes.Internal, "error reading state of Chiltrix heat pump: %v", err)
+	}
+	return state.Proto(), nil
+}


### PR DESCRIPTION
Before: cx34.Client implemented the generated ReadWriteServiceServer gRPC interface.

Now: cx34.Client returns an implementation of ReadWriteServiceServer when one of its methods is called.